### PR TITLE
Enable long-running commands that can be terminated or interrupted.

### DIFF
--- a/Mac Host/SBTUITunnelHostServer.xcodeproj/project.pbxproj
+++ b/Mac Host/SBTUITunnelHostServer.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1F6DB57823CBDB9800D3D5EA /* ProcessEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F6DB57723CBDB9800D3D5EA /* ProcessEnvironment.swift */; };
 		72EB04F079F767286CF2155F /* Pods_SBTUITunnelHostServer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E8C34FAC177FA8F229FCFD33 /* Pods_SBTUITunnelHostServer.framework */; };
 		856701DA1FE130A0007C2221 /* SimulatorDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 856701D91FE130A0007C2221 /* SimulatorDescriptor.swift */; };
 		C34E6CAC1CF44D2D004D96DD /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C34E6CAB1CF44D2D004D96DD /* AppDelegate.swift */; };
@@ -23,6 +24,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		1F6DB57723CBDB9800D3D5EA /* ProcessEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessEnvironment.swift; sourceTree = "<group>"; };
 		1FCA6BB9513E6E4E58CED026 /* Pods-SBTUITunnelHostServer.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SBTUITunnelHostServer.release.xcconfig"; path = "Pods/Target Support Files/Pods-SBTUITunnelHostServer/Pods-SBTUITunnelHostServer.release.xcconfig"; sourceTree = "<group>"; };
 		27D23485823996586D87D674 /* Pods-SBTUITunnelHostServer.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SBTUITunnelHostServer.debug.xcconfig"; path = "Pods/Target Support Files/Pods-SBTUITunnelHostServer/Pods-SBTUITunnelHostServer.debug.xcconfig"; sourceTree = "<group>"; };
 		856701D91FE130A0007C2221 /* SimulatorDescriptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimulatorDescriptor.swift; sourceTree = "<group>"; };
@@ -110,6 +112,7 @@
 			children = (
 				C3A745041ECA3E84007B57F5 /* SBTMouseClick.swift */,
 				C3A745061ECA3E98007B57F5 /* SBTMouseDrag.swift */,
+				1F6DB57723CBDB9800D3D5EA /* ProcessEnvironment.swift */,
 			);
 			path = Classes;
 			sourceTree = "<group>";
@@ -252,6 +255,7 @@
 			files = (
 				C3CA5A481EB8AC8800B8717E /* CatHandler.swift in Sources */,
 				C3CA5A491EB8AC8800B8717E /* ExecHandler.swift in Sources */,
+				1F6DB57823CBDB9800D3D5EA /* ProcessEnvironment.swift in Sources */,
 				C3A745071ECA3E98007B57F5 /* SBTMouseDrag.swift in Sources */,
 				C34E6CAC1CF44D2D004D96DD /* AppDelegate.swift in Sources */,
 				856701DA1FE130A0007C2221 /* SimulatorDescriptor.swift in Sources */,
@@ -334,6 +338,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";

--- a/Mac Host/SBTUITunnelHostServer/Classes/ProcessEnvironment.swift
+++ b/Mac Host/SBTUITunnelHostServer/Classes/ProcessEnvironment.swift
@@ -1,0 +1,114 @@
+//
+//  ProcessEnvironment.swift
+//  SBTUITunnelHostServer
+//
+//  Created by Jeff Kelley on 1/12/20.
+//  Copyright © 2020 Subito.it. All rights reserved.
+//
+
+import Foundation
+
+struct ProcessEnvironment {
+    
+    enum Status {
+        
+        case running(pid: Int32)
+
+        case finished(
+            standardOutput: String?,
+            standardError: String?,
+            terminationStatus: Int32,
+            terminationReason: Process.TerminationReason
+        )
+        
+    }
+
+    let task = Process()
+    let standardOutputPipe = Pipe()
+    let standardErrorPipe = Pipe()
+    
+    let id = UUID()
+    
+    init(_ cmd: String, basePath: String) {
+        task.standardOutput = standardOutputPipe
+        task.standardError = standardErrorPipe
+        
+        task.currentDirectoryPath = basePath
+        task.launchPath = "/bin/sh"
+        
+        task.arguments = ["-c", cmd]
+        
+        task.terminationHandler = { process in
+            print("Process \(process.processIdentifier) terminated")
+        }
+    }
+    
+    @discardableResult
+    func launch() -> Int32 {
+        task.launch()
+        return task.processIdentifier
+    }
+    
+    func interrupt() {
+        task.interrupt()
+    }
+    
+    func terminate() {
+        task.terminate()
+    }
+    
+    func waitUntilExit() {
+        task.waitUntilExit()
+    }
+    
+    var standardOutput: String? {
+        guard task.isRunning == false else { return nil }
+        
+        let data = standardOutputPipe.fileHandleForReading.readDataToEndOfFile()
+        
+        guard let output = String(data: data, encoding: .utf8)
+            else { return nil }
+        
+        return output
+    }
+    
+    var standardError: String? {
+        guard task.isRunning == false else { return nil }
+        
+        let data = standardErrorPipe.fileHandleForReading.readDataToEndOfFile()
+        
+        guard let error = String(data: data, encoding: .utf8)
+            else { return nil }
+        
+        return error
+    }
+    
+    var status: Status {
+        if task.isRunning {
+            return .running(pid: task.processIdentifier)
+        }
+        else {
+            return .finished(standardOutput: standardOutput,
+                             standardError: standardError,
+                             terminationStatus: task.terminationStatus,
+                             terminationReason: task.terminationReason)
+        }
+    }
+    
+}
+
+extension ProcessEnvironment: Equatable {
+    
+    static func ==(lhs: ProcessEnvironment, rhs: ProcessEnvironment) -> Bool {
+        return lhs.id == rhs.id
+    }
+    
+}
+
+extension ProcessEnvironment: Hashable {
+    
+    func hash(into hasher: inout Hasher) {
+        id.hash(into: &hasher)
+    }
+    
+}

--- a/Mac Host/SBTUITunnelHostServer/Handlers/ExecHandler.swift
+++ b/Mac Host/SBTUITunnelHostServer/Handlers/ExecHandler.swift
@@ -22,61 +22,169 @@ class ExecHandler: BaseHandler {
     
     private let requestMethod = "POST"
     private var executablesBasePath = "~/Desktop"
-
-    func addHandler(_ webServer: GCDWebServer, menubarUpdated: @escaping ((String) -> ())) {
-        let requestClass = (requestMethod == "POST") ? GCDWebServerURLEncodedFormRequest.self : GCDWebServerRequest.self
+    
+    private func parseCommand(_ params: [AnyHashable: Any]) -> String? {
+        guard let encodedCommand = params["command"] as? String,
+            let decdedData = Data(base64Encoded: encodedCommand),
+            let decodedCommand = String(data: decdedData, encoding: .utf8)
+            else { return nil }
         
-        webServer.addHandler(forMethod: requestMethod, path: "/exec", request: requestClass, processBlock: { request in
-            guard let requestPath = request?.path else {
-                menubarUpdated("Unknown path")
-                return GCDWebServerErrorResponse(statusCode: 701)
+        return decodedCommand
+    }
+    
+    private func parseUUID(_ params: [AnyHashable: Any]) -> UUID? {
+        guard let idString = params["command"] as? String else {
+            return nil
+        }
+        
+        return UUID(uuidString: idString)
+    }
+    
+    private func responseForCommandStatus(
+        _ status: ProcessEnvironment.Status?
+    ) -> GCDWebServerResponse {
+        switch status {
+        case .none:
+            return GCDWebServerResponse(statusCode: 404)
+        case .running(pid: let pid):
+            return GCDWebServerDataResponse(jsonObject: ["result": [
+                "pid": pid
+                ]
+            ])
+        case let .finished(standardOutput: stdOut,
+                           standardError: stdErr, 
+                           terminationStatus: status,
+                           terminationReason: reason):
+            var jsonObject: [String : Any] = [
+                "terminationStatus": status,
+                "terminationReason": reason.rawValue
+            ]
+            
+            if let stdOut = stdOut {
+                jsonObject["stdOut"] = stdOut
             }
             
-            switch requestPath {
-            case "/exec":
-                let params = (self.requestMethod == "POST") ? (request as! GCDWebServerURLEncodedFormRequest).arguments : request?.query
-                
-                guard self.validToken(params) else {
-                    menubarUpdated("Check token")
-                    return GCDWebServerErrorResponse(statusCode: 702)
-                }
-                
-                if let cmdB64 = params?["command"] as? String,
-                    let cmdData = Data(base64Encoded: cmdB64, options: NSData.Base64DecodingOptions(rawValue: 0)),
-                    var cmd = String(data: cmdData, encoding: String.Encoding.utf8) {
+            if let stdErr = stdErr {
+                jsonObject["stdErr"] = stdErr
+            }
+            
+            return GCDWebServerDataResponse(
+                jsonObject: ["result": jsonObject]
+            )
+        }
+    }
+    
+    private func validate(
+        command: String,
+        errorHandler: (String) -> Void
+    ) -> GCDWebServerErrorResponse? {
+        var cmd = command
+        
+        do {
+            let regex = try NSRegularExpression(pattern: ".*?(?:(;|&))", options: .caseInsensitive)
+            
+            regex.enumerateMatches(in: cmd, options: NSRegularExpression.MatchingOptions(rawValue: 0), range: NSMakeRange(0, cmd.count)) {
+                (substringRange: NSTextCheckingResult?, _, _) in
+                if let substringRange = substringRange {
+                    let cmd2 = cmd as NSString
                     
-                    do {
-                        let regex = try NSRegularExpression(pattern: ".*?(?:(;|&))", options: .caseInsensitive)
-                        
-                        regex.enumerateMatches(in: cmd, options: NSRegularExpression.MatchingOptions(rawValue: 0), range: NSMakeRange(0, cmd.count)) {
-                            (substringRange: NSTextCheckingResult?, _, _) in
-                            if let substringRange = substringRange {
-                                let cmd2 = cmd as NSString
-                                
-                                cmd = cmd2.substring(with: substringRange.range)
-                            }
-                        }
-                        
-                        if cmd.hasPrefix("rm ") {
-                            menubarUpdated("WTF!")
-                            return GCDWebServerErrorResponse(statusCode: 703)
-                        }
-                    } catch {
-                        menubarUpdated("Regex failed?")
-                        return GCDWebServerErrorResponse(statusCode: 704)
+                    cmd = cmd2.substring(with: substringRange.range)
+                }
+            }
+            
+            if cmd.hasPrefix("rm ") {
+                errorHandler("WTF!")
+                return GCDWebServerErrorResponse(statusCode: 703)
+            }
+            else {
+                return nil
+            }
+        } catch {
+            errorHandler("Regex failed?")
+            return GCDWebServerErrorResponse(statusCode: 704)
+        }
+    }
+    
+    func addHandler(_ webServer: GCDWebServer,
+                    menubarUpdated: @escaping ((String) -> ())) {
+        let requestClass = (requestMethod == "POST") ?
+            GCDWebServerURLEncodedFormRequest.self :
+            GCDWebServerRequest.self
+        
+        func addHandlerForParameter<T>(
+            _ path: String,
+            parser paramsParser: @escaping ([AnyHashable: Any]) -> T?,
+            responseForItem: @escaping ((T) -> GCDWebServerResponse)
+        ) {
+            webServer.addHandler(
+                forMethod: self.requestMethod, 
+                path: path,
+                request: requestClass,
+                processBlock: { request in
+                    let params = (self.requestMethod == "POST") ? (request as! GCDWebServerURLEncodedFormRequest).arguments : request?.query
+                    
+                    guard self.validToken(params) else {
+                        menubarUpdated("Check token")
+                        return GCDWebServerErrorResponse(statusCode: 702)
                     }
                     
-                    let cmdOutput = executeShellCommand(cmd, basePath: self.executablesBasePath)
-                    menubarUpdated("Executed: \(cmd)")
-                    return GCDWebServerDataResponse(jsonObject: ["result": cmdOutput, "status": 1])
-                } else {
-                    menubarUpdated("Missing parameter!")
-                    return GCDWebServerErrorResponse(statusCode: 705)
-                }
-            default:
-                menubarUpdated("Unkown command")
-                return GCDWebServerErrorResponse(statusCode: 706)
+                    guard let p = params, let item = paramsParser(p) else {
+                        menubarUpdated("Missing parameter!")
+                        return GCDWebServerErrorResponse(statusCode: 705)
+                    }
+                    
+                    return responseForItem(item)
+            })
+        }
+        
+        addHandlerForParameter("/exec", parser: parseCommand) { command in
+            if let error = self.validate(command: command,
+                                         errorHandler: menubarUpdated) {
+                return error
             }
-        })
+            
+            let cmdOutput = executeShellCommand(
+                command,
+                basePath: self.executablesBasePath
+            )
+            
+            menubarUpdated("Executed: \(command)")
+            
+            return GCDWebServerDataResponse(jsonObject: [
+                "result": cmdOutput,
+                "status": 1
+            ])
+        }
+        
+        addHandlerForParameter("/launch", parser: parseCommand) { command in
+            if let error = self.validate(command: command,
+                                         errorHandler: menubarUpdated) {
+                return error
+            }
+            
+            let id = launchShellCommand(command,
+                                        basePath: self.executablesBasePath)
+            
+            menubarUpdated("Launch: \(command)")
+            
+            return GCDWebServerDataResponse(jsonObject: [
+                "result": id.uuidString,
+                "status": 1
+            ])
+        }
+        
+        addHandlerForParameter("/status", parser: parseUUID) { id in
+            return self.responseForCommandStatus(getShellCommandStatus(for: id))
+        }
+                
+        addHandlerForParameter("/interrupt", parser: parseUUID) { id in
+            return self.responseForCommandStatus(interruptCommand(with: id))
+        }
+                
+        addHandlerForParameter("/terminate", parser: parseUUID) { id in
+            return self.responseForCommandStatus(terminateCommand(with: id))
+        }
+                
     }
+
 }

--- a/SBTUITestTunnelHost/SBTUITunneledHost.h
+++ b/SBTUITestTunnelHost/SBTUITunneledHost.h
@@ -34,11 +34,43 @@ typedef NS_ENUM(NSInteger, SBTUITunneledHostLogLevel) {
 - (void)connect;
 
 /**
- *  Command to execute on the host
+ *  Command to execute on the host. Waits for the command to finish.
  *
  *  @return command result. Nil if command failed or connnection did timeout
  */
 - (NSString *)executeCommand:(NSString *)command;
+
+/**
+ *  Command to launch a command on the host. Returns immediately.
+ *  
+ *  @return The command ID. Use this ID for the @c -getStatusOfCommandWithID:
+ *          and @c -terminateCommandWithID: methods.
+ */
+- (NSUUID *)launchCommand:(NSString *)command;
+
+/**
+ *  Command to get the status of a command on the host.
+ *  
+ *  @return An @c NSDictionary containing the status of the command, or @c nil
+ *          if no command is found with the given UUID.
+ */
+- (NSDictionary *)getStatusOfCommandWithID:(NSUUID *)commandID;
+
+/**
+*  Command to interrupt a command on the host. Sends a @c SIGINT signal.
+*  
+*  @return An @c NSDictionary containing the status of the command, or @c nil
+*          if no command is found with the given UUID.
+*/
+- (NSDictionary *)interruptCommandWithID:(NSUUID *)commandID;
+
+/**
+*  Command to interrupt a command on the host. Sends a @c SIGTERM signal.
+*  
+*  @return An @c NSDictionary containing the status of the command, or @c nil
+*          if no command is found with the given UUID.
+*/
+- (NSDictionary *)terminateCommandWithID:(NSUUID *)commandID;
 
 /**
  *  Command to execute a sequence of SBTUITunneledHostMouseClick


### PR DESCRIPTION
This PR adds the ability for the Mac host to launch commands that run asynchronously. For instance you can use `simctl io` to record video during your UI tests. To do this, there are four new commands added as siblings of `exec`:

- `launch` begins a process
- `status` reports the process of a status, including its standard input/output
- `interrupt` sends a `SIGINT` signal to the process and reports its status back
- `terminate` sends a `SIGTERM` signal to the process and reports its status back

Processes are identified by UUIDs to avoid any potential conflicts with process IDs.