### PR TITLE
Use `Process.run()` to report errors

### DIFF
--- a/SBTUITunnelHostServer/Sources/Classes/ProcessEnvironment.swift
+++ b/SBTUITunnelHostServer/Sources/Classes/ProcessEnvironment.swift
@@ -37,8 +37,8 @@ struct ProcessEnvironment {
     }
 
     @discardableResult
-    func launch() -> Int32 {
-        task.launch()
+    func run() throws -> Int32 {
+        try task.run()
         return task.processIdentifier
     }
 

--- a/SBTUITunnelHostServer/Sources/Handlers/ExecHandler.swift
+++ b/SBTUITunnelHostServer/Sources/Handlers/ExecHandler.swift
@@ -105,29 +105,47 @@ class ExecHandler: BaseHandler {
         }
 
         addHandlerForParameter("/exec", parser: parseCommand) { command in
-            let cmdOutput = executeShellCommand(
-                command,
-                basePath: self.executablesBasePath
-            )
+            do {
+                let cmdOutput = try executeShellCommand(
+                    command,
+                    basePath: self.executablesBasePath
+                )
 
-            menubarUpdated("Executed: \(command)")
+                menubarUpdated("Executed: \(command)")
 
-            return GCDWebServerDataResponse(jsonObject: [
-                "result": cmdOutput,
-                "status": 1
-            ])
+                return GCDWebServerDataResponse(jsonObject: [
+                    "result": cmdOutput,
+                    "status": 1
+                ])
+            } catch {
+                menubarUpdated("Failed to execute: \(command) - \(error.localizedDescription)")
+
+                return GCDWebServerDataResponse(jsonObject: [
+                    "result": error.localizedDescription,
+                    "status": -1
+                ])
+            }
         }
 
         addHandlerForParameter("/launch", parser: parseCommand) { command in
-            let id = launchShellCommand(command,
-                                        basePath: self.executablesBasePath)
+            do {
+                let id = try launchShellCommand(command,
+                                                basePath: self.executablesBasePath)
 
-            menubarUpdated("Launch: \(command)")
+                menubarUpdated("Launch: \(command)")
 
-            return GCDWebServerDataResponse(jsonObject: [
-                "result": id.uuidString,
-                "status": 1
-            ])
+                return GCDWebServerDataResponse(jsonObject: [
+                    "result": id.uuidString,
+                    "status": 1
+                ])
+            } catch {
+                menubarUpdated("Failed to execute: \(command) - \(error.localizedDescription)")
+
+                return GCDWebServerDataResponse(jsonObject: [
+                    "result": error.localizedDescription,
+                    "status": -1
+                ])
+            }
         }
 
         addHandlerForParameter("/status", parser: parseUUID) { id in

--- a/SBTUITunnelHostServer/Sources/ShellCommands.swift
+++ b/SBTUITunnelHostServer/Sources/ShellCommands.swift
@@ -20,10 +20,10 @@
 
 import Foundation
 
-func executeShellCommand(_ cmd: String, basePath: String) -> String {
+func executeShellCommand(_ cmd: String, basePath: String) throws -> String {
     let processEnvironment = ProcessEnvironment(cmd, basePath: basePath)
 
-    processEnvironment.launch()
+    try processEnvironment.run()
     processEnvironment.waitUntilExit()
 
     return (processEnvironment.standardOutput ?? "") +
@@ -32,9 +32,9 @@ func executeShellCommand(_ cmd: String, basePath: String) -> String {
 
 private var runningProcesses = Set<ProcessEnvironment>()
 
-func launchShellCommand(_ cmd: String, basePath: String) -> UUID {
+func launchShellCommand(_ cmd: String, basePath: String) throws -> UUID {
     let processEnvironment = ProcessEnvironment(cmd, basePath: basePath)
-    processEnvironment.launch()
+    try processEnvironment.run()
 
     runningProcesses.insert(processEnvironment)
 


### PR DESCRIPTION
Otherwise no response is returned on some errors (e.g. invalid working directory) as `Process.waitForExit()` never returns.