### PR TITLE
Change default working directory to `~`

### DIFF
--- a/SBTUITunnelHostServer/Sources/Handlers/ExecHandler.swift
+++ b/SBTUITunnelHostServer/Sources/Handlers/ExecHandler.swift
@@ -23,7 +23,7 @@ import GCDWebServer
 
 class ExecHandler: BaseHandler {
     private let requestMethod = "POST"
-    private var executablesBasePath = "~/Desktop"
+    private var executablesBasePath = "~"
 
     private func parseCommand(_ params: [AnyHashable: Any]) -> String? {
         guard let encodedCommand = params["command"] as? String,


### PR DESCRIPTION
The server can run in an environment that doesn’t have a `~/Desktop` folder.